### PR TITLE
Update config.env

### DIFF
--- a/docker/config.env
+++ b/docker/config.env
@@ -16,7 +16,8 @@ OPENRELIK_WORKER_EXTRACTION_VERSION=latest
 OPENRELIK_WORKER_ANALYZER_CONFIG_VERSION=latest
 
 # Change these
-OPENRELIK_SERVER_URL=http://localhost:8710
+OPENRELIK_SERVER_URL=http://localhost:8710 
+# OPENRELIK_SERVER_URL=http://{HOST-IP-ADDRESS}:8710 # make Openrelik accessible via additional host-nginx on LAN. 
 OPENRELIK_API_VERSION=v1
 
 # PostgreSQL PATH local DB


### PR DESCRIPTION
added line: # OPENRELIK_SERVER_URL=http://{HOST-IP-ADDRESS}:8710 # make Openrelik accessible via additional host-nginx on LAN.

I don't know where to place it , but to make Openrelik accessible to LAN , I installed a dedicated nginx on my host with following config: 

cat /etc/nginx/sites-available/openrelik 

server {
    listen 80;
    server_name 10.10.0.116;
    client_max_body_size 100M;
    # First handle all API calls - they should go to 8710
    location ~ ^/auth/ {
        proxy_pass http://127.0.0.1:8710;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
    }

    location /api/ {
	client_max_body_size 100M;	
        proxy_pass http://127.0.0.1:8710;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
   	
	proxy_read_timeout 600;
        proxy_connect_timeout 600;
        proxy_send_timeout 600; 
   }

    # Frontend assets
    location ~* ^/(assets/|favicon.png|logo.*\.png) {
        proxy_pass http://127.0.0.1:8711;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
    }

    # Everything else goes to frontend
    location / {
        proxy_pass http://127.0.0.1:8711;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;

    }
}



( I know, chaining reverse proxies isn't the best solution, it's more a quick and dirty hack)  