### PR TITLE
Set default docker compose network name.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -159,3 +159,6 @@ volumes:
       o: bind
       device: ./config/prometheus
 
+networks:
+  default:
+    name: openrelik_default


### PR DESCRIPTION
Set the default docker compose network name to `openrelik_default`. Docker normally sets the network name based on the foldername the docker compose configuration file is in. 

When spinning up different docker compose stacks with their own docker compose configuration file (eg for logging and metrics or even for other (private) workers) the below configuration can then be added to those docker compose configuration files to have the stack join the main openrelik docker compose network. Containers are reachable and can be dns resolved that way.

This is beneficial because we can seperate eg metrics and logging containers/stacks from the main openrelik server/worker stack.

Configuration to add to other docker compose confiuguration files to join the network:
```
networks:
  default:
    name: openrelik_default
    external: true
```