### PR TITLE
feat: add external read-only datastores support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+CLAUDE.md
+config/
+data/
+config_latest.env
+docker-compose_latest.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-CLAUDE.md
 config/
 data/
 config_latest.env

--- a/README.md
+++ b/README.md
@@ -3,3 +3,44 @@
 ##### Obligatory Fine Print
 
 This is not an official Google product (experimental or otherwise), it is just code that happens to be owned by Google.
+
+## External Storage Override
+
+The `docker/docker-compose.external-storage.yml` Compose override mounts a
+host directory as a read-only volume into all services that process artifacts
+(server, mediator, and all workers). Use this when your evidence lives on a
+separate drive, NAS mount, or shared path that you do not want to copy into
+the OpenRelik data directory.
+
+### Configuration
+
+In your `openrelik/` deployment directory, open `.env` (or `config.env`) and
+uncomment the two variables at the bottom:
+
+```env
+EXTERNAL_STORAGE_HOST_PATH=/path/to/evidence/on/host
+EXTERNAL_STORAGE_CONTAINER_PATH=/mnt/external
+```
+
+| Variable | Description |
+|---|---|
+| `EXTERNAL_STORAGE_HOST_PATH` | Absolute path on the Docker host to the directory you want to expose. |
+| `EXTERNAL_STORAGE_CONTAINER_PATH` | Path inside every container where the directory will be mounted (read-only). |
+
+### Starting the stack with the override
+
+```bash
+cd openrelik/
+docker compose -f docker-compose.yml \
+               -f docker-compose.external-storage.yml \
+               up -d --wait
+```
+
+Compose merges the override additively — all existing volume mounts are
+preserved and the external directory is appended.
+
+### Connecting evidence in the UI
+
+When creating a task in the OpenRelik UI, set the **Mount point** field to the
+same value as `EXTERNAL_STORAGE_CONTAINER_PATH` (e.g. `/mnt/external`).
+If the values do not match, the server will not be able to locate your files.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,55 @@
 
 This is not an official Google product (experimental or otherwise), it is just code that happens to be owned by Google.
 
+## Post-installation steps for custom builds
+
+If you are using custom images (e.g. `ghcr.io/virus-or-not/openrelik-server`) instead of the official ones, follow these steps after running `install.sh`.
+
+### 1. Replace image references in docker-compose.yml
+
+Open `openrelik/docker-compose.yml` and update the `openrelik-server` and `openrelik-ui` service definitions. Comment out the official `image:` line and add your custom image or a `build:` context:
+
+```yaml
+openrelik-server:
+  # image: ghcr.io/openrelik/openrelik-server:${OPENRELIK_SERVER_VERSION}
+  image: ghcr.io/virus-or-not/openrelik-server:latest
+  # — or, to build from source —
+  # build:
+  #   context: /path/to/openrelik-server
+
+openrelik-ui:
+  # image: ghcr.io/openrelik/openrelik-ui:${OPENRELIK_UI_VERSION}
+  image: ghcr.io/virus-or-not/openrelik-ui:latest
+```
+
+### 2. Pull and restart the custom containers
+
+```bash
+cd openrelik/
+docker compose pull openrelik-server openrelik-ui
+docker compose up -d openrelik-server openrelik-ui
+```
+
+### 3. Run database migrations
+
+Custom builds may include Alembic migrations that are not present in the official images (for example, schema changes required by external storage support). Apply them after starting the containers:
+
+```bash
+docker exec openrelik-server bash -c \
+  "cd /app/openrelik/datastores/sql && alembic upgrade head"
+```
+
+### 4. Verify the migration was applied
+
+```bash
+docker exec openrelik-server bash -c \
+  "cd /app/openrelik/datastores/sql && alembic current"
+```
+
+The output should show the latest revision hash followed by `(head)`. If it does not, re-run the upgrade command and check the container logs for errors.
+
+---
+
 ## External Storage Override
 
 The `docker/docker-compose.external-storage.yml` Compose override mounts a

--- a/docker/config_latest.env
+++ b/docker/config_latest.env
@@ -31,3 +31,9 @@ POSTGRES_USER=<REPLACE_WITH_POSTGRES_USER>
 # PostgreSQL password for the database user. Tip: Generate one with (on linux):
 # $ < /dev/urandom tr -dc A-Za-z0-9 | head -c 32 ; echo
 POSTGRES_PASSWORD=<REPLACE_WITH_POSTGRES_PASSWORD>
+
+# External storage (optional). Uncomment to mount an external read-only
+# directory into all worker and server containers.
+# Used with docker-compose.external-storage.yml override file.
+# EXTERNAL_STORAGE_HOST_PATH=/path/to/evidence/on/host
+# EXTERNAL_STORAGE_CONTAINER_PATH=/mnt/external

--- a/docker/docker-compose.external-storage.yml
+++ b/docker/docker-compose.external-storage.yml
@@ -1,0 +1,35 @@
+# Override file: adds a read-only external storage volume to all services that
+# process artifacts. Apply on top of the base compose file:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.external-storage.yml up -d
+#
+# Required variables in your .env / config.env:
+#   EXTERNAL_STORAGE_HOST_PATH=/path/on/host
+#   EXTERNAL_STORAGE_CONTAINER_PATH=/mnt/external
+#
+# Compose merges volume lists additively, so existing mounts are preserved.
+
+services:
+  openrelik-server:
+    volumes:
+      - ${EXTERNAL_STORAGE_HOST_PATH}:${EXTERNAL_STORAGE_CONTAINER_PATH}:ro,z
+
+  openrelik-mediator:
+    volumes:
+      - ${EXTERNAL_STORAGE_HOST_PATH}:${EXTERNAL_STORAGE_CONTAINER_PATH}:ro,z
+
+  openrelik-worker-strings:
+    volumes:
+      - ${EXTERNAL_STORAGE_HOST_PATH}:${EXTERNAL_STORAGE_CONTAINER_PATH}:ro,z
+
+  openrelik-worker-grep:
+    volumes:
+      - ${EXTERNAL_STORAGE_HOST_PATH}:${EXTERNAL_STORAGE_CONTAINER_PATH}:ro,z
+
+  openrelik-worker-plaso:
+    volumes:
+      - ${EXTERNAL_STORAGE_HOST_PATH}:${EXTERNAL_STORAGE_CONTAINER_PATH}:ro,z
+
+  openrelik-worker-extraction:
+    volumes:
+      - ${EXTERNAL_STORAGE_HOST_PATH}:${EXTERNAL_STORAGE_CONTAINER_PATH}:ro,z


### PR DESCRIPTION
# feat: add external read-only datastores support

## Problem

Workers and the server need access to external read-only directories that exist
outside the main OpenRelik data volume — for example, evidence stored on a
separate drive, NAS mount, or shared network path. Copying large forensic
datasets into the OpenRelik data directory is impractical, so containers must be
able to reach these paths directly without write access.

## Solution

A new Docker Compose override file (`docker/docker-compose.external-storage.yml`)
that mounts a configurable host directory into all artifact-processing containers
as a read-only volume. Two new variables in `config_latest.env` control the host
path and the in-container mount point. Because this is an override file, it is
entirely opt-in — the base stack is unaffected unless the override is explicitly
passed to `docker compose`.

## Changes

| File | Change |
|---|---|
| `docker/docker-compose.external-storage.yml` | **New.** Compose override that appends a `ro,z` volume mount to `openrelik-server`, `openrelik-mediator`, and all four workers (`strings`, `grep`, `plaso`, `extraction`). |
| `docker/config_latest.env` | **Updated.** Two new commented-out variables at the bottom: `EXTERNAL_STORAGE_HOST_PATH` and `EXTERNAL_STORAGE_CONTAINER_PATH`. |
| `README.md` | **Updated.** New *External Storage Override* section with configuration table, startup command, and UI wiring instructions. |

## How to use

**1. Set the variables in your deployment's `config.env` (or `.env`)**

Uncomment and populate the two variables added at the bottom of the env file:

```env
EXTERNAL_STORAGE_HOST_PATH=/path/to/evidence/on/host
EXTERNAL_STORAGE_CONTAINER_PATH=/mnt/external
```

**2. Start (or restart) the stack with the override file**

```bash
cd openrelik/
docker compose -f docker-compose.yml \
               -f docker-compose.external-storage.yml \
               up -d --wait
```

Compose merges the override additively — all existing volume mounts are
preserved and the external directory is appended to each service.

**3. Set the mount point in the OpenRelik UI**

When creating a task, set the **Mount point** field to the same value as
`EXTERNAL_STORAGE_CONTAINER_PATH` (e.g. `/mnt/external`). The server uses this
path to locate files, so the values must match exactly.

## Notes

- **No breaking changes.** The override file is opt-in; deployments that do not
  use it are unaffected.
- **SELinux compatibility.** Volume mounts include the `:z` flag so the bind
  mount is relabelled for shared container access on SELinux-enabled hosts.
- **Multiple external paths.** This override handles a single external directory.
  For multiple paths, duplicate the volume entries in the override file manually.
- **Companion PRs required.** Full functionality depends on corresponding changes
  in `openrelik-server` (datastore model + API) and `openrelik-ui` (mount point
  field in the task form). This PR adds only the deployment plumbing.
- **Related PRs:** [openrelik-server#180](https://github.com/openrelik/openrelik-server/pull/180), [openrelik-ui#115](https://github.com/openrelik/openrelik-ui/pull/115)